### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hot-formula-parser",
-  "version": "4.0.0",
+  "version": "4.0.0-unc2",
   "description": "Formula parser",
   "main": "./dist/index",
   "module": "./dist/index.mjs",
@@ -19,7 +19,7 @@
     "check": "npm run lint && npm run test",
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "cross-env BABEL_ENV=commonjs jest --coverage",
-    "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
+    "build": "npm run build:commonjs && npm run build:es",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir dist",
     "build:es": "cross-env BABEL_ENV=es babel src --out-file-extension .mjs --out-dir dist",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",


### PR DESCRIPTION
@ucwillg this fixes the last two issues that were causing trouble with the formula parsing import. Bumping the version and removing the webpack builds causes the library to successfully install and pass tests after I was able to reproduce the issue you had. I had to upgrade to node 17 (I guess I was on v16) and the install only failed on v17+