### PR TITLE
allow division by zero to resolve to Infinity

### DIFF
--- a/dist/evaluate-by-operator/operator/divide.mjs
+++ b/dist/evaluate-by-operator/operator/divide.mjs
@@ -8,11 +8,11 @@ export default function func(first) {
 
   var result = rest.reduce(function (acc, value) {
     return acc / toNumber(value);
-  }, toNumber(first));
-
-  if (result === Infinity) {
-    throw Error(ERROR_DIV_ZERO);
-  }
+  }, toNumber(first)); // allowing Infinity so cases like 1 / (100 / var) where var is 0 to resolve to 0 instead of error
+  // this is the current logic on the backend
+  // if (result === Infinity) {
+  //   throw Error(ERROR_DIV_ZERO);
+  // }
 
   if (isNaN(result)) {
     throw Error(ERROR_VALUE);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hot-formula-parser",
-  "version": "4.2.0-unc4",
+  "version": "4.3.0-unc6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hot-formula-parser",
-      "version": "4.2.0-unc4",
+      "version": "4.3.0-unc6",
       "license": "MIT",
       "dependencies": {
         "@handsontable/formulajs": "^2.0.2",
@@ -17,7 +17,7 @@
         "@babel/core": "^7.12.10",
         "@babel/preset-env": "^7.12.10",
         "babel-loader": "^8.2.2",
-        "cross-env": "^5.2.0",
+        "cross-env": "^5.2.1",
         "eslint": "^4.2.0",
         "eslint-config-airbnb-base": "^11.2.0",
         "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hot-formula-parser",
-  "version": "4.3.0-unc5",
+  "version": "4.3.0-unc6",
   "description": "Formula parser",
   "main": "./dist/index",
   "module": "./dist/index.mjs",
@@ -51,7 +51,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.10",
     "babel-loader": "^8.2.2",
-    "cross-env": "^5.2.0",
+    "cross-env": "^5.2.1",
     "eslint": "^4.2.0",
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.14.0",

--- a/src/evaluate-by-operator/operator/divide.js
+++ b/src/evaluate-by-operator/operator/divide.js
@@ -6,9 +6,11 @@ export const SYMBOL = '/';
 export default function func(first, ...rest) {
   const result = rest.reduce((acc, value) => acc / toNumber(value), toNumber(first));
 
-  if (result === Infinity) {
-    throw Error(ERROR_DIV_ZERO);
-  }
+  // allowing Infinity so cases like 1 / (100 / var) where var is 0 to resolve to 0 instead of error
+  // this is the current logic on the backend
+  // if (result === Infinity) {
+  //   throw Error(ERROR_DIV_ZERO);
+  // }
   if (isNaN(result)) {
     throw Error(ERROR_VALUE);
   }


### PR DESCRIPTION
This is required to resolve this ticket: https://uncount.atlassian.net/browse/MAT-19851

The goal is to have the frontend respond the same as the backend, so we need to allow 1 / 0 = Infinity

Example use case: backend resolves 1 / (100 / var) = 0 where var is 0.